### PR TITLE
Update OpeningHours.php for using the class member $timezone

### DIFF
--- a/src/OpeningHours.php
+++ b/src/OpeningHours.php
@@ -523,6 +523,9 @@ class OpeningHours
 
     public function asStructuredData(string $format = 'H:i', $timezone = null): array
     {
+        if (!isset($timezone)) {
+            $timezone = $this->timezone;
+        }
         $regularHours = $this->flatMap(function (OpeningHoursForDay $openingHoursForDay, string $day) use ($format, $timezone) {
             return $openingHoursForDay->map(function (TimeRange $timeRange) use ($format, $timezone, $day) {
                 return [


### PR DESCRIPTION
Thanks a lot for the recent patch to fix the timezone issue exporting structured data. Here's one more suggestion... Since we have a class member `$timezone`, I suggest that it's automatically passed to the `format` function.

Otherwise, beautiful work! This seems like a very clean solution to me.